### PR TITLE
🚑 Fix Ingress sidebar icon with Home Assistant 0.113+

### DIFF
--- a/log-viewer/config.json
+++ b/log-viewer/config.json
@@ -9,7 +9,7 @@
   "init": false,
   "ingress": true,
   "ingress_port": 1337,
-  "panel_icon": "mdi:file-document-box-outline",
+  "panel_icon": "mdi:text-box-outline",
   "homeassistant": "0.92.0b2",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "homeassistant_api": true,


### PR DESCRIPTION
# Proposed Changes

icon rename updated fixes #32

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/