### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/log-viewer/config.json
+++ b/log-viewer/config.json
@@ -4,7 +4,6 @@
   "slug": "logviewer",
   "description": "Browser-based log utility for Home Assistant",
   "url": "https://github.com/hassio-addons/addon-log-viewer",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "init": false,
   "ingress": true,
   "ingress_port": 1337,


### PR DESCRIPTION
# Proposed Changes

Since this add-on has ingress, the webui link is ignored and thus can be removed.